### PR TITLE
Clarify installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Special thanks to [Guido](https://github.com/guwidoe) for his contribution (see 
 
 ## Installation
 
-Download the [latest release](https://github.com/cristianbuse/VBA-FastDictionary/releases/latest), extract and import the ```Dictionary.cls``` class into your project.
+Download and extract the source code (zip) from the [latest release](https://github.com/cristianbuse/VBA-FastDictionary/releases/latest), navigate to the `src` folder and import the ```Dictionary.cls``` class into your project.
 
 Although the ```OLE Automation``` project reference should be enabled by default (fundamental COM), please enable it if it's disabled. For more details see [OLE Automation](https://github.com/cristianbuse/VBA-FastDictionary/blob/master/Implementation.md#ole-automation) section.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Special thanks to [Guido](https://github.com/guwidoe) for his contribution (see 
 
 ## Installation
 
-Download and extract the source code (zip) from the [latest release](https://github.com/cristianbuse/VBA-FastDictionary/releases/latest), navigate to the `src` folder and import the ```Dictionary.cls``` class into your project.
+Download and extract the source code (zip) from the [latest release](https://github.com/cristianbuse/VBA-FastDictionary/releases/latest), and import the ```Dictionary.cls``` file (located in the `src` folder) into your project.
 
 Although the ```OLE Automation``` project reference should be enabled by default (fundamental COM), please enable it if it's disabled. For more details see [OLE Automation](https://github.com/cristianbuse/VBA-FastDictionary/blob/master/Implementation.md#ole-automation) section.
 


### PR DESCRIPTION
Updated installation instructions to clarify source code extraction and file location. I know this might be obvious, but for newcomers, it can never be clear enough!

Sidenote: Perhaps it would be better to include the Dictionary.cls file directly in the release. This way people can download it directly and you get a nice download counter like I have for my pomodoro timer:

<img width="936" height="244" alt="image" src="https://github.com/user-attachments/assets/4b0c6b0a-19f3-4b1a-92d3-1f8674997ed4" />


